### PR TITLE
Long Transformation

### DIFF
--- a/src/clj/summit/sap/order.clj
+++ b/src/clj/summit/sap/order.clj
@@ -3,7 +3,7 @@
 (ns summit.sap.order
   (:require [summit.sap.core :refer :all]
             [clojure.string :as str]
-            [summit.utils.core :as utils :refer [->int as-document-num ppn]]
+            [summit.utils.core :as utils :refer [->int ->long as-document-num ppn]]
             [summit.sap.lookup-tables :as lookup-tables :refer [deliver-statuses shipping-types]]
             ))
 
@@ -34,7 +34,8 @@
           shipping-name (shipping-types (:shipping-type line-item))]
       {:id                 (str order-id "-" line-item-id)
        :account-id         (->int (:customer line-item))
-       :job-account-id     (:job-account line-item)
+       ;; :job-account-id     (:job-account line-item)
+       :job-account-id     (->long (:job-account line-item))
        :order-id           order-id
        :product-id         (->int (:material line-item))
        :delivered-quantity (:delivered-qty line-item)
@@ -49,7 +50,7 @@
 (defn transform-order-summary [order]
   {:id               (->int (:order order))
    :account-id       (->int (:customer order))
-   :job-account-id   (:job-account order)
+   :job-account-id   (->long (:job-account order))
    :bill-address-id  (->int (:bill-address-code order))
    :pay-address-id   (->int (:pay-address-code order))
    :ship-address-id  (->int (:ship-address-code order))

--- a/src/clj/summit/utils/core.clj
+++ b/src/clj/summit/utils/core.clj
@@ -47,6 +47,16 @@
           (Double/parseDouble v)))
       (double v))))
 
+(defn ->long [v]
+  (if (nil? v)
+    nil
+    (if (string? v)
+      (let [v (str/trim v)]
+        (if (empty? v)
+          nil
+          (-> v Double/parseDouble long)))
+      (long v))))
+
 (defn as-integer [string]
   (->int string))
 


### PR DESCRIPTION
Added `->long` to the set of transformers in SAP utils core and it is
now being utilized in transforming the job-account id in the order api.
